### PR TITLE
Fix a bug making the ringing view only appear the first time

### DIFF
--- a/src/AgentApp.tsx
+++ b/src/AgentApp.tsx
@@ -63,7 +63,10 @@ const AgentApp = ({
         const wrapUpTimeLeftInSeconds = Math.floor(agent.wrapUpTimeLeft / 1000);
         setWrapUpTimeLeft(wrapUpTimeLeftInSeconds);
       }
-      setView('waiting');
+      setView((currentView) => {
+        if (currentView === 'ringing') return 'ringing';
+        return 'waiting';
+      });
     });
   };
 


### PR DESCRIPTION
Fix a bug happening when an agent `no_answer_delay_time` is too low (0) meaning the call will rotate instantly making `snapcallEvent_ringing` and `snapcallEvent_callEnd` happen almost at the same time.