### PR TITLE
Comment npmjs publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
-          scope: '@snapcall'
+          scope: '@snapcall_'
       - run: npm install
       - run: npm publish
         env:
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v2.1.5
         with:
           registry-url: 'https://npm.pkg.github.com'
+          scope: '@snapcall'
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,14 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
-          scope: '@snapcall_'
+          scope: '@snapcall'
       - run: npm install
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #- run: npm publish
+      #  env:
+      #    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: actions/setup-node@v2.1.5
         with:
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@snapcall'
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "type": "git",
     "url": "git://github.com/snapcall/agent-app-react.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",


### PR DESCRIPTION
Comment out npmjs publish in the release workflow for now, since we don't own the `@snapcall` organization there (yet).