### PR TITLE
Remove margin from the Video element

### DIFF
--- a/src/components/video/style.ts
+++ b/src/components/video/style.ts
@@ -4,7 +4,6 @@ export const VideoWrapper = styled.div`
   position: relative;
   padding-bottom: 56.25%;
   width: 100%;
-  margin-bottom: 20px;
 `;
 
 export const VideoContainer = styled.div<{ idle: boolean }>`

--- a/src/views/ringing.tsx
+++ b/src/views/ringing.tsx
@@ -8,7 +8,7 @@ const Ringing = ({ answer }: RingingViewProps) => {
   return (
     <FlexCard>
       <Video hideControls />
-      <Button kind="primary" onClick={answer}>
+      <Button kind="primary" onClick={answer} style={{ marginTop: '20px' }}>
         Answer
       </Button>
     </FlexCard>

--- a/src/views/style.tsx
+++ b/src/views/style.tsx
@@ -20,6 +20,7 @@ export const ButtonsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   width: 100%;
+  margin-top: 20px;
 
   button {
     flex: 1;

--- a/src/views/waiting.tsx
+++ b/src/views/waiting.tsx
@@ -25,7 +25,7 @@ const Waiting = ({
       ) : (
         <>
           <Video hideControls />
-          <Button kind="secondary" disabled>
+          <Button kind="secondary" style={{ marginTop: '20px' }} disabled>
             Waiting for a call...
           </Button>
           <Separator />


### PR DESCRIPTION
Since we expose the **Video** element, it shouldn't have any margin, to make sure developers can easily integrate it anywhere.