### PR TITLE
Remove PictureInPicture types

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -39,13 +39,3 @@ export interface InCallViewProps {
   timer: number;
   Video: React.ComponentType<VideoProps>;
 }
-
-declare global {
-  interface Document {
-    pictureInPictureEnabled: boolean;
-  }
-
-  interface HTMLVideoElement {
-    requestPictureInPicture: () => void;
-  }
-}


### PR DESCRIPTION
Types related to the PictureInPicture API have been added in TypeScript 4.4, we don't need to define those ourselves anymore 🎉