### PR TITLE
Revert "Remove PictureInPicture types"

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -39,3 +39,13 @@ export interface InCallViewProps {
   timer: number;
   Video: React.ComponentType<VideoProps>;
 }
+
+declare global {
+  interface Document {
+    pictureInPictureEnabled: boolean;
+  }
+
+  interface HTMLVideoElement {
+    requestPictureInPicture: () => void;
+  }
+}


### PR DESCRIPTION
Reverts snapcall/agent-app-react#149

TSDX is using TypeScript 3.9 under the hood and it seems that upgrading to 4.4 won't happen anytime soon.
Reverting this changes is the easiest fix 😔