### PR TITLE
Fix icons size on mobile devices

### DIFF
--- a/src/components/dialpad/style.tsx
+++ b/src/components/dialpad/style.tsx
@@ -8,6 +8,7 @@ export const DialpadButton = styled.button`
   background-color: unset;
   border: none;
   cursor: pointer;
+  padding: 0;
 `;
 
 export const DialpadMenu = styled.div`

--- a/src/components/video/style.ts
+++ b/src/components/video/style.ts
@@ -76,6 +76,7 @@ export const VideoButton = styled.button`
   border: none;
   border-radius: 50%;
   color: white;
+  padding: 1px 6px;
 
   span {
     display: flex;


### PR DESCRIPTION
This issue is caused because of the default padding applied to `button` elements.

<img width="200px" src="https://user-images.githubusercontent.com/8902831/135647187-0bb93a7e-0a35-4256-aae5-d1bed7a52db9.png" />