### PR TITLE
Fix remote video pausing after exiting picture in picture

### DIFF
--- a/src/components/video/index.tsx
+++ b/src/components/video/index.tsx
@@ -68,8 +68,24 @@ const Video = ({ timer, hideControls }: VideoProps) => {
     }
   }, [isScreenSharing]);
 
+  const onLeavePictureInPicture = () => {
+    window.snapcallAPI.displayRemoteVideo(remoteVideoRef.current);
+    remoteVideoRef.current?.removeEventListener(
+      'leavepictureinpicture',
+      onLeavePictureInPicture
+    );
+  };
+
   const onPictureInPictureClick = () => {
-    remoteVideoRef.current?.requestPictureInPicture();
+    if (document.pictureInPictureElement) {
+      document.exitPictureInPicture?.();
+    } else {
+      remoteVideoRef.current?.requestPictureInPicture();
+      remoteVideoRef.current?.addEventListener(
+        'leavepictureinpicture',
+        onLeavePictureInPicture
+      );
+    }
   };
 
   const onRemoteStream = () => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -43,6 +43,8 @@ export interface InCallViewProps {
 declare global {
   interface Document {
     pictureInPictureEnabled: boolean;
+    pictureInPictureElement: Element;
+    exitPictureInPicture: () => void;
   }
 
   interface HTMLVideoElement {


### PR DESCRIPTION
Fix a small issue making the remote video pause when exiting picture in picture mode.

Calling `snapcallAPI.displayRemoteVideo` on PiP exit fixes the issue.