### PR TITLE
Clean fix for pause after PiP exit

### DIFF
--- a/src/components/video/index.tsx
+++ b/src/components/video/index.tsx
@@ -77,37 +77,13 @@ const Video = ({ timer, hideControls }: VideoProps) => {
     }
   }, [isScreenSharing]);
 
-  const onLeaveLocalPictureInPicture = () => {
-    window.snapcallAPI.requestLocalVideo(localWebcamRef.current);
-    localWebcamRef.current?.removeEventListener(
-      'leavepictureinpicture',
-      onLeaveLocalPictureInPicture
-    );
-  };
-
-  const onLeaveRemotePictureInPicture = () => {
-    window.snapcallAPI.displayRemoteVideo(remoteVideoRef.current);
-    remoteVideoRef.current?.removeEventListener(
-      'leavepictureinpicture',
-      onLeaveRemotePictureInPicture
-    );
-  };
-
   const onPictureInPictureClick = () => {
     if (document.pictureInPictureElement) {
       document.exitPictureInPicture?.();
     } else if (isRemoteMainVideo) {
       remoteVideoRef.current?.requestPictureInPicture();
-      remoteVideoRef.current?.addEventListener(
-        'leavepictureinpicture',
-        onLeaveRemotePictureInPicture
-      );
     } else {
       localWebcamRef.current?.requestPictureInPicture();
-      localWebcamRef.current?.addEventListener(
-        'leavepictureinpicture',
-        onLeaveLocalPictureInPicture
-      );
     }
   };
 
@@ -122,6 +98,14 @@ const Video = ({ timer, hideControls }: VideoProps) => {
   const onRemoteStreamEnd = () => {
     setIsReceivingRemoteStream(false);
     setIsIdle(false);
+  };
+
+  const onLocalVideoPause = () => {
+    localWebcamRef.current?.play();
+  };
+
+  const onRemoteVideoPause = () => {
+    remoteVideoRef.current?.play();
   };
 
   const onMouseMove = () => {
@@ -168,6 +152,8 @@ const Video = ({ timer, hideControls }: VideoProps) => {
       'snapcallEvent_onScreenSharingStreamStop',
       onRemoteStreamEnd
     );
+    localWebcamRef.current?.addEventListener('pause', onLocalVideoPause);
+    remoteVideoRef.current?.addEventListener('pause', onRemoteVideoPause);
     window.snapcallAPI.displayRemoteVideo(remoteVideoRef.current);
     return () => {
       window.removeEventListener(


### PR DESCRIPTION
Exiting the Picture in Picture mode by clicking on the close icon will pause the video stream.
It was fixed in #161 

This PR brings a cleaner fix, instead of calling again `snapcallAPI.requestLocalVideo` and `snapcallAPI.displayRemoteVideo`, we just listen for the `pause` event and use the `video.play()` method.