### PR TITLE
Replace deprecated clientHold with toggleHold

### DIFF
--- a/src/AgentApp.tsx
+++ b/src/AgentApp.tsx
@@ -276,7 +276,7 @@ const AgentApp = ({
     return (
       <InCallView
         hangUp={window.snapcallAPI.endCall}
-        toggleHold={window.snapcallAPI.clientHold}
+        toggleHold={window.snapcallAPI.toggleHold}
         timer={callTimer}
         Video={Video}
       />


### PR DESCRIPTION
Fixes the following warning:
```
[ deprecated ] snapcall: clientHold is deprecated, please use toggleHold
```